### PR TITLE
 [IMP] grap_account_export_ebp : view changes (show disabled partners)

### DIFF
--- a/grap_account_export_ebp/views/view_account_tax.xml
+++ b/grap_account_export_ebp/views/view_account_tax.xml
@@ -23,25 +23,36 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         </field>
     </record>
 
-<!--     <record id="view_account_tax_form" model="ir.ui.view">
+    <record id="view_account_tax_form" model="ir.ui.view">
         <field name="model">account.tax</field>
-        <field name="inherit_id" ref="account.view_tax_code_form" />
+        <field name="inherit_id" ref="account.view_tax_form" />
         <field name="arch" type="xml">
-            <field name="code" position="after">
+            <field name="name" position="after">
                 <field name="ebp_suffix"/>
             </field>
         </field>
-    </record> -->
+    </record>
 
     <record id="view_account_tax_tree" model="ir.ui.view">
         <field name="model">account.tax</field>
+        <field name="inherit_id" ref="account.view_tax_tree"/>
         <field name="arch" type="xml">
-            <tree editable="bottom">
+            <field name="name" position="after">
+                <field name="ebp_suffix"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="view_account_tax_tree_editable" model="ir.ui.view">
+        <field name="model">account.tax</field>
+        <field name="arch" type="xml">
+            <tree editable="bottom" decoration-muted="active == False">
                 <field name="name" readonly="True"/>
                 <field name="type_tax_use" readonly="True"/>
                 <field name="description" readonly="True"/>
                 <field name="ebp_suffix"/>
                 <field name="has_ebp_suffix_required"/>
+                <field name="active" readonly="True"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </tree>
         </field>
@@ -53,8 +64,11 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="res_model">account.tax</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree</field>
-        <field name="view_id" ref="view_account_tax_tree"/>
-        <field name="context">{'search_default_filter_has_ebp_suffix_required': 1}</field>
+        <field name="view_id" ref="view_account_tax_tree_editable"/>
+        <field name="context">{
+            'search_default_filter_has_ebp_suffix_required': 1,
+            'active_test': False
+            }</field>
     </record>
 
     <menuitem id="menu_account_tax_code"

--- a/grap_account_export_ebp/views/view_res_partner.xml
+++ b/grap_account_export_ebp/views/view_res_partner.xml
@@ -39,13 +39,14 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
     <record id="view_res_partner_tree" model="ir.ui.view">
         <field name="model">res.partner</field>
         <field name="arch" type="xml">
-            <tree string="Partner" editable="bottom">
+            <tree editable="bottom" decoration-muted="active == False">
                 <field name="name" readonly="1"/>
                 <field name="ebp_suffix"/>
                 <field name="has_ebp_move_line"/>
                 <field name="journal_item_count" readonly="1"/>
                 <field name="customer" readonly="1"/>
                 <field name="supplier" readonly="1"/>
+                <field name="active" readonly="1"/>
                 <field name="company_id" readonly="1" groups="base.group_multi_company"/>
             </tree>
         </field>
@@ -58,7 +59,10 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="view_type">form</field>
         <field name="view_mode">tree</field>
         <field name="view_id" ref="view_res_partner_tree"/>
-        <field name="context">{'search_default_without_suffix_with_move_line_ebp': 1}</field>
+        <field name="context">{
+            'search_default_without_suffix_with_move_line_ebp': 1,
+            'active_test': False
+            }</field>
     </record>
 
     <menuitem id="menu_partner_suffix"


### PR DESCRIPTION
- display disabled partners for suffixes (recurring problem with accountant, when user disable partner with accounting activity) 
- display partner in gray in list view, if disabled
- display ebp suffix on account.tax form view. (bah oui, c'est quoi cette migration pas finie...)
- display ebp suffix on account.tax tree view.

task : apps/deck/#/board/144/card/1683