### PR TITLE
 [FIX] grap_pos_change_payment_move_filter : do not allow to close statement if the state is not open

### DIFF
--- a/grap_pos_change_payment_move/models/account_bank_statement.py
+++ b/grap_pos_change_payment_move/models/account_bank_statement.py
@@ -26,7 +26,7 @@ class AccountBankStatement(models.Model):
         AccountMove = self.env["account.move"]
         AccountBankStatementLine = self.env["account.bank.statement.line"]
 
-        for statement in self:
+        for statement in self.filtered(lambda r: r.state == 'open'):
             move_ids = []
             groups = {}
             # parse the lines to group the ids according to the key fields


### PR DESCRIPTION
Ref : apps/deck/?debug=0#/board/144/card/1943

do not allow to close statement if the state is not open. (see original code : https://github.com/odoo/odoo/blob/12.0/addons/account/models/account_bank_statement.py#L236)